### PR TITLE
Fix undo history for image resize and improve TOC editing

### DIFF
--- a/src/Dialogs/EditTOC.cpp
+++ b/src/Dialogs/EditTOC.cpp
@@ -1,6 +1,6 @@
 /************************************************************************
 **
-**  Copyright (C) 2016-2024 Kevin B. Hendricks, Stratford, Ontario, Canada
+**  Copyright (C) 2016-2026 Kevin B. Hendricks, Stratford, Ontario, Canada
 **  Copyright (C) 2013      Dave Heiland
 **
 **  This file is part of Sigil.
@@ -20,8 +20,10 @@
 **
 *************************************************************************/
 
-#include <QtCore/QStringList>
-#include <QtGui/QStandardItem>
+#include <QStringList>
+#include <QStandardItem>
+#include <QItemSelection>
+#include <QItemSelectionRange>
 #include <QKeyEvent>
 #include <QTimer>
 
@@ -69,6 +71,7 @@ EditTOC::EditTOC(QSharedPointer<Book> book, QList<Resource *> resources, QWidget
     ui.TOCTree->installEventFilter(this);
     ui.TOCTree->setModel(m_TableOfContents);
     ui.TOCTree->setIndentation(COLUMN_INDENTATION);
+    ui.TOCTree->setSelectionMode(QAbstractItemView::ExtendedSelection);
     CreateContextMenuActions();
     ConnectSignalsToSlots();
 
@@ -160,137 +163,223 @@ void EditTOC::ExpandChildren(QStandardItem *item)
 
 void EditTOC::MoveLeft()
 {
-    QModelIndex index = CheckSelection(0);
-    if (!index.isValid()) {
+    if (!ui.TOCTree->selectionModel()->hasSelection()) {
         return;
     }
-
-    QStandardItem *item = m_TableOfContents->itemFromIndex(index);
-
-    QStandardItem *parent_item = item->parent();
-    // Can't indent above top level
-    if (!parent_item) {
-        return;
+    QList<QStandardItem*> moved_items;
+    QItemSelection selection = ui.TOCTree->selectionModel()->selection();
+    for (const QItemSelectionRange& arange : selection) {
+        qDebug() << "original ranges: " << arange.parent().row() << arange.top() << arange.bottom();
     }
+    for(int i = selection.size()-1; i >= 0; i--) {
+        QItemSelectionRange range = selection.at(i);
+        qDebug() << "new range: " << range.parent().row() << range.top() << range.bottom();
+        QModelIndex parent = range.parent();
+        if (!parent.isValid()) continue;
 
-    QStandardItem *grandparent_item = parent_item->parent();
-    if (!grandparent_item) {
-        grandparent_item = m_TableOfContents->invisibleRootItem();
+        QStandardItem *parent_item = m_TableOfContents->itemFromIndex(parent);
+        if (!parent_item) continue;
+        int parent_row = parent_item->row();
+
+        QStandardItem *grandparent_item = parent_item->parent();
+        if (!grandparent_item) {
+            grandparent_item = m_TableOfContents->invisibleRootItem();
+        }
+        int top_row = range.top();
+        int bottom_row = range.bottom();
+        int row_to_take = top_row;
+        int row_to_put = parent_row + 1;
+        for (int r = top_row; r <= bottom_row; r++) {
+#if 0        
+            QModelIndex index = m_TableOfContents->index(r, 0, parent);
+            if (!index.isValid()) continue;
+            QStandardItem* item = m_TableOfContents->itemFromIndex(index);
+            // Make siblings following the entry into children
+            while (row + 1 < parent_item->rowCount()) {
+                QList<QStandardItem *> row_items = parent_item->takeRow(row + 1);
+                int row_count = item->rowCount();
+                item->setChild(row_count, 0, row_items[0]);
+                item->setChild(row_count, 1, row_items[1]);
+            }
+ #endif           
+            // Make child of grandparent
+            QList<QStandardItem *> row_items = parent_item->takeRow(row_to_take);
+            // grandparent_item->insertRow(parent_row+1, row_items);
+            // QModelIndex new_item_index = grandparent_item->child(parent_row + 1)->index();
+            grandparent_item->insertRow(row_to_put, row_items);
+            QStandardItem* new_item = grandparent_item->child(row_to_put);
+            moved_items << new_item;
+            row_to_put++;
+        }
     }
-
-    // Make siblings following the entry into children
-    int row = item->row() ;
-    while (row + 1 < parent_item->rowCount()) {
-        QList<QStandardItem *> row_items = parent_item->takeRow(row + 1);
-        int row_count = item->rowCount();
-        item->setChild(row_count, 0, row_items[0]);
-        item->setChild(row_count, 1, row_items[1]);
-    }
-
-    // Make item child of grandparent
-    int parent_row = parent_item->row();
-    QList<QStandardItem *> row_items = parent_item->takeRow(row);
-    grandparent_item->insertRow(parent_row + 1, row_items);
-
-    // Reselect the item
-    QModelIndex item_index = grandparent_item->child(parent_row + 1)->index();
+    
+    // Reselect the now moved items
     ui.TOCTree->selectionModel()->clear();
-    ui.TOCTree->setCurrentIndex(item_index);
-    ui.TOCTree->selectionModel()->select(item_index, QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-    ExpandChildren(grandparent_item->child(parent_row + 1));
+    QItemSelection nselection;
+    foreach (QStandardItem* item, moved_items) {
+        QModelIndex index = item->index();
+        if (index.isValid()) {
+            int row = item->row();
+            QModelIndex parent_index = index.parent();
+            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
+            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
+            QItemSelection aselection;
+            aselection.select(topleft, bottomright);
+            nselection.merge(aselection,QItemSelectionModel::Select);
+        }
+    }
+    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
+    // Expand Children
+    foreach(QStandardItem* item, moved_items) {
+        ExpandChildren(item);
+    }
+    // ExpandChildren(grandparent_item->child(parent_row + 1));
 }
+
 
 void EditTOC::MoveRight()
 {
-    QModelIndex index = CheckSelection(0);
-    if (!index.isValid()) {
+    if (!ui.TOCTree->selectionModel()->hasSelection()) {
         return;
     }
-
-    QStandardItem *item = m_TableOfContents->itemFromIndex(index);
-    int item_row = item->row();
-
-    // Can't indent if row above is already parent
-    if (item_row == 0) {
-        return;
+    QList<QStandardItem*> moved_items;
+    QItemSelection selection = ui.TOCTree->selectionModel()->selection();
+    for (const QItemSelectionRange& range : selection) {
+        QModelIndex parent = range.parent();
+        QStandardItem *parent_item = m_TableOfContents->itemFromIndex(parent);
+        if (!parent_item) {
+            parent_item = m_TableOfContents->invisibleRootItem();
+        }
+        // int leftColumn = range.left();
+        // int rightColumn = range.right();
+        int top_row = range.top();
+        int bottom_row = range.bottom();
+        if (top_row == 0) continue;
+        QStandardItem *new_parent = parent_item->child(top_row - 1, 0);
+        // removing a row will move up sequentially following rows by 1
+        int row_to_take = top_row;
+        for (int r = top_row; r <= bottom_row; r++) {
+            if (r == 0) continue;
+            QList<QStandardItem *> row_items = parent_item->takeRow(row_to_take);
+            new_parent->insertRow(new_parent->rowCount(), row_items);
+            QStandardItem *new_item = new_parent->child(new_parent->rowCount()-1, 0);
+            moved_items << new_item;
+        }
     }
-
-    QStandardItem *parent_item = item->parent();
-    if (!parent_item) {
-        parent_item = m_TableOfContents->invisibleRootItem();
-    }
-
-    // Make the item above the parent of this item
-    QList<QStandardItem *> row_items = parent_item->takeRow(item_row);
-    QStandardItem *new_parent = parent_item->child(item_row - 1, 0);
-    new_parent->insertRow(new_parent->rowCount(), row_items);
-    QStandardItem *new_item = new_parent->child(new_parent->rowCount() - 1, 0);
-
-    // Reselect the item
+    // Reselect the now moved items
     ui.TOCTree->selectionModel()->clear();
-    ui.TOCTree->setCurrentIndex(item->index());
-    ui.TOCTree->selectionModel()->select(item->index(), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-    ExpandChildren(new_item);
+    QItemSelection nselection;
+    foreach(QStandardItem* item, moved_items) {
+        QModelIndex index = item->index();
+        if (index.isValid()) {
+            int row = item->row();
+            QModelIndex parent_index = index.parent();
+            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
+            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
+            QItemSelection aselection;
+            aselection.select(topleft, bottomright);
+            nselection.merge(aselection,QItemSelectionModel::Select);
+        }
+    }
+    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
+    // Expand Children
+    foreach(QStandardItem* item, moved_items) {
+        ExpandChildren(item);
+    }
 }
 
 void EditTOC::MoveUp()
 {
-    QModelIndex index = CheckSelection(0);
-    if (!index.isValid()) {
-        return;
+    QModelIndexList chosen_indexes = CheckSelections();
+    if (chosen_indexes.isEmpty()) return;
+    
+    QList<QStandardItem*> moved_items;
+    
+    for (int i=0; i < chosen_indexes.count(); i++) {
+        QModelIndex index = chosen_indexes.at(i);
+        if (index.isValid()) {
+            QStandardItem *item = m_TableOfContents->itemFromIndex(index);
+            QStandardItem *parent_item = item->parent();
+            if (!parent_item) {
+                parent_item = m_TableOfContents->invisibleRootItem();
+            }
+            int item_row = item->row();
+
+            // Can't move up if this row is already the top one
+            if (item_row == 0) continue;
+
+            QList<QStandardItem *> row_items = parent_item->takeRow(item_row);
+            parent_item->insertRow(item_row - 1, row_items);
+            moved_items << item;        
+        }
     }
-    QStandardItem *item = m_TableOfContents->itemFromIndex(index);
-
-    int item_row = item->row();
-
-    // Can't move up if this row is already the top most one of its parent
-    if (item_row == 0) {
-        return;
-    }
-
-    QStandardItem *parent_item = item->parent();
-    if (!parent_item) {
-        parent_item = m_TableOfContents->invisibleRootItem();
-    }
-
-    QList<QStandardItem *> row_items = parent_item->takeRow(item_row);
-    parent_item->insertRow(item_row - 1, row_items);
-
-    // Reselect the item
+    // Reselect the now moved items
     ui.TOCTree->selectionModel()->clear();
-    ui.TOCTree->setCurrentIndex(item->index());
-    ui.TOCTree->selectionModel()->select(item->index(), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-    ExpandChildren(item);
+    QItemSelection nselection;
+    foreach(QStandardItem* item, moved_items) {
+        QModelIndex index = item->index();
+        if (index.isValid()) {
+            int row = item->row();
+            QModelIndex parent_index = index.parent();
+            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
+            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
+            QItemSelection aselection;
+            aselection.select(topleft, bottomright);
+            nselection.merge(aselection,QItemSelectionModel::Select);
+        }
+    }
+    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
+    // Expand Children
+    foreach(QStandardItem* item, moved_items) {
+        ExpandChildren(item);
+    }
 }
 
 void EditTOC::MoveDown()
 {
-    QModelIndex index = CheckSelection(0);
-    if (!index.isValid()) {
-        return;
+    QModelIndexList chosen_indexes = CheckSelections();
+    if (chosen_indexes.isEmpty()) return;
+    
+    QList<QStandardItem*> moved_items;
+
+    for (int i=chosen_indexes.count()-1; i >= 0; i--) {
+        QModelIndex index = chosen_indexes.at(i);
+        if (index.isValid()) {
+            QStandardItem *item = m_TableOfContents->itemFromIndex(index);
+            QStandardItem *parent_item = item->parent();
+            if (!parent_item) {
+                parent_item = m_TableOfContents->invisibleRootItem();
+            }
+            int item_row = item->row();
+
+            // Can't move down if this row is already the last one of its parent
+            if (item_row == parent_item->rowCount() - 1) continue;
+
+            QList<QStandardItem *> row_items = parent_item->takeRow(item_row);
+            parent_item->insertRow(item_row + 1, row_items);
+            moved_items << item;
+        }
     }
-    QStandardItem *item = m_TableOfContents->itemFromIndex(index);
-
-    QStandardItem *parent_item = item->parent();
-    if (!parent_item) {
-        parent_item = m_TableOfContents->invisibleRootItem();
-    }
-
-    int item_row = item->row();
-
-    // Can't move down if this row is already the last one of its parent
-    if (item_row == parent_item->rowCount() - 1) {
-        return;
-    }
-
-    QList<QStandardItem *> row_items = parent_item->takeRow(item_row);
-    parent_item->insertRow(item_row + 1, row_items);
-
-    // Reselect the item
+    // Reselect the now moved items
     ui.TOCTree->selectionModel()->clear();
-    ui.TOCTree->setCurrentIndex(item->index());
-    ui.TOCTree->selectionModel()->select(item->index(), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-    ExpandChildren(item);
+    QItemSelection nselection;
+    foreach(QStandardItem* item, moved_items) {
+        QModelIndex index = item->index();
+        if (index.isValid()) {
+            int row = item->row();
+            QModelIndex parent_index = index.parent();
+            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
+            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
+            QItemSelection aselection;
+            aselection.select(topleft, bottomright);
+            nselection.merge(aselection,QItemSelectionModel::Select);
+        }
+    }
+    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
+    // Expand Children
+    foreach(QStandardItem* item, moved_items) {
+        ExpandChildren(item);
+    }
 }
 
 void EditTOC::AddEntryAbove()
@@ -346,6 +435,17 @@ void EditTOC::MakeDefaultFirstSelection()
 }
 
 
+QModelIndexList EditTOC::CheckSelections()
+{
+    if (!ui.TOCTree->selectionModel()->hasSelection()) {
+        return QModelIndexList();
+    }
+
+    QModelIndexList selected_indexes = ui.TOCTree->selectionModel()->selectedRows();
+    return selected_indexes;
+}
+
+
 QModelIndex EditTOC::CheckSelection(int row)
 {
     if (!ui.TOCTree->selectionModel()->hasSelection()) {
@@ -353,11 +453,9 @@ QModelIndex EditTOC::CheckSelection(int row)
     }
 
     QModelIndexList selected_indexes = ui.TOCTree->selectionModel()->selectedRows(row);
-
     if (selected_indexes.count() != 1) {
         return QModelIndex();
     }
-
     return selected_indexes.first();
 }
 

--- a/src/Dialogs/EditTOC.cpp
+++ b/src/Dialogs/EditTOC.cpp
@@ -161,6 +161,30 @@ void EditTOC::ExpandChildren(QStandardItem *item)
     ui.TOCTree->expand(item->index());
 }
 
+void EditTOC::ReselectAndExpandItems(const QList<QStandardItem*> &items)
+{
+    // Reselect the now moved items
+    ui.TOCTree->selectionModel()->clear();
+    QItemSelection nselection;
+    foreach (QStandardItem* item, items) {
+        QModelIndex index = item->index();
+        if (index.isValid()) {
+            int row = item->row();
+            QModelIndex parent_index = index.parent();
+            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
+            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
+            QItemSelection aselection;
+            aselection.select(topleft, bottomright);
+            nselection.merge(aselection,QItemSelectionModel::Select);
+        }
+    }
+    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
+    // Expand Children
+    foreach(QStandardItem* item, items) {
+        ExpandChildren(item);
+    }
+}
+
 void EditTOC::MoveLeft()
 {
     if (!ui.TOCTree->selectionModel()->hasSelection()) {
@@ -168,12 +192,9 @@ void EditTOC::MoveLeft()
     }
     QList<QStandardItem*> moved_items;
     QItemSelection selection = ui.TOCTree->selectionModel()->selection();
-    for (const QItemSelectionRange& arange : selection) {
-        qDebug() << "original ranges: " << arange.parent().row() << arange.top() << arange.bottom();
-    }
+
     for(int i = selection.size()-1; i >= 0; i--) {
         QItemSelectionRange range = selection.at(i);
-        qDebug() << "new range: " << range.parent().row() << range.top() << range.bottom();
         QModelIndex parent = range.parent();
         if (!parent.isValid()) continue;
 
@@ -190,7 +211,12 @@ void EditTOC::MoveLeft()
         int row_to_take = top_row;
         int row_to_put = parent_row + 1;
         for (int r = top_row; r <= bottom_row; r++) {
-#if 0        
+
+#if 0
+            // given we are selecting and moving full rows, this should NOT be needed
+            // but was in the original code for some reason, keep until after testing
+            // is complete then discard if truly not needed
+            
             QModelIndex index = m_TableOfContents->index(r, 0, parent);
             if (!index.isValid()) continue;
             QStandardItem* item = m_TableOfContents->itemFromIndex(index);
@@ -201,11 +227,9 @@ void EditTOC::MoveLeft()
                 item->setChild(row_count, 0, row_items[0]);
                 item->setChild(row_count, 1, row_items[1]);
             }
- #endif           
+#endif
             // Make child of grandparent
             QList<QStandardItem *> row_items = parent_item->takeRow(row_to_take);
-            // grandparent_item->insertRow(parent_row+1, row_items);
-            // QModelIndex new_item_index = grandparent_item->child(parent_row + 1)->index();
             grandparent_item->insertRow(row_to_put, row_items);
             QStandardItem* new_item = grandparent_item->child(row_to_put);
             moved_items << new_item;
@@ -213,29 +237,8 @@ void EditTOC::MoveLeft()
         }
     }
     
-    // Reselect the now moved items
-    ui.TOCTree->selectionModel()->clear();
-    QItemSelection nselection;
-    foreach (QStandardItem* item, moved_items) {
-        QModelIndex index = item->index();
-        if (index.isValid()) {
-            int row = item->row();
-            QModelIndex parent_index = index.parent();
-            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
-            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
-            QItemSelection aselection;
-            aselection.select(topleft, bottomright);
-            nselection.merge(aselection,QItemSelectionModel::Select);
-        }
-    }
-    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
-    // Expand Children
-    foreach(QStandardItem* item, moved_items) {
-        ExpandChildren(item);
-    }
-    // ExpandChildren(grandparent_item->child(parent_row + 1));
+    ReselectAndExpandItems(moved_items);
 }
-
 
 void EditTOC::MoveRight()
 {
@@ -250,8 +253,6 @@ void EditTOC::MoveRight()
         if (!parent_item) {
             parent_item = m_TableOfContents->invisibleRootItem();
         }
-        // int leftColumn = range.left();
-        // int rightColumn = range.right();
         int top_row = range.top();
         int bottom_row = range.bottom();
         if (top_row == 0) continue;
@@ -266,26 +267,7 @@ void EditTOC::MoveRight()
             moved_items << new_item;
         }
     }
-    // Reselect the now moved items
-    ui.TOCTree->selectionModel()->clear();
-    QItemSelection nselection;
-    foreach(QStandardItem* item, moved_items) {
-        QModelIndex index = item->index();
-        if (index.isValid()) {
-            int row = item->row();
-            QModelIndex parent_index = index.parent();
-            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
-            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
-            QItemSelection aselection;
-            aselection.select(topleft, bottomright);
-            nselection.merge(aselection,QItemSelectionModel::Select);
-        }
-    }
-    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
-    // Expand Children
-    foreach(QStandardItem* item, moved_items) {
-        ExpandChildren(item);
-    }
+    ReselectAndExpandItems(moved_items);
 }
 
 void EditTOC::MoveUp()
@@ -304,7 +286,6 @@ void EditTOC::MoveUp()
                 parent_item = m_TableOfContents->invisibleRootItem();
             }
             int item_row = item->row();
-
             // Can't move up if this row is already the top one
             if (item_row == 0) continue;
 
@@ -313,26 +294,7 @@ void EditTOC::MoveUp()
             moved_items << item;        
         }
     }
-    // Reselect the now moved items
-    ui.TOCTree->selectionModel()->clear();
-    QItemSelection nselection;
-    foreach(QStandardItem* item, moved_items) {
-        QModelIndex index = item->index();
-        if (index.isValid()) {
-            int row = item->row();
-            QModelIndex parent_index = index.parent();
-            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
-            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
-            QItemSelection aselection;
-            aselection.select(topleft, bottomright);
-            nselection.merge(aselection,QItemSelectionModel::Select);
-        }
-    }
-    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
-    // Expand Children
-    foreach(QStandardItem* item, moved_items) {
-        ExpandChildren(item);
-    }
+    ReselectAndExpandItems(moved_items);
 }
 
 void EditTOC::MoveDown()
@@ -360,26 +322,7 @@ void EditTOC::MoveDown()
             moved_items << item;
         }
     }
-    // Reselect the now moved items
-    ui.TOCTree->selectionModel()->clear();
-    QItemSelection nselection;
-    foreach(QStandardItem* item, moved_items) {
-        QModelIndex index = item->index();
-        if (index.isValid()) {
-            int row = item->row();
-            QModelIndex parent_index = index.parent();
-            QModelIndex topleft = m_TableOfContents->index(row, 0, parent_index);
-            QModelIndex bottomright = m_TableOfContents->index(row, 1, parent_index);
-            QItemSelection aselection;
-            aselection.select(topleft, bottomright);
-            nselection.merge(aselection,QItemSelectionModel::Select);
-        }
-    }
-    ui.TOCTree->selectionModel()->select(nselection, QItemSelectionModel::Select | QItemSelectionModel::Current);
-    // Expand Children
-    foreach(QStandardItem* item, moved_items) {
-        ExpandChildren(item);
-    }
+    ReselectAndExpandItems(moved_items);
 }
 
 void EditTOC::AddEntryAbove()

--- a/src/Dialogs/EditTOC.h
+++ b/src/Dialogs/EditTOC.h
@@ -85,6 +85,7 @@ private:
     void AddEntryToParentItem(const TOCModel::TOCEntry &entry, QStandardItem *parent, int level);
 
     void ExpandChildren(QStandardItem *item);
+    void ReselectAndExpandItems(const QList<QStandardItem*> &items);
 
     void CreateContextMenuActions();
     void SetupContextMenu(const QPoint &point);

--- a/src/Dialogs/EditTOC.h
+++ b/src/Dialogs/EditTOC.h
@@ -1,6 +1,6 @@
 /************************************************************************
 **
-**  Copyright (C) 2016-2024 Kevin B. Hendricks, Stratford, Ontario, Canada
+**  Copyright (C) 2016-2026 Kevin B. Hendricks, Stratford, Ontario, Canada
 **  Copyright (C) 2013      Dave Heiland
 **
 **  This file is part of Sigil.
@@ -76,6 +76,7 @@ private slots:
 private:
     void AddEntry(bool above);
     QModelIndex CheckSelection(int row);
+    QModelIndexList CheckSelections();
 
     TOCModel::TOCEntry ConvertTableToEntries();
     TOCModel::TOCEntry ConvertItemToEntry(QStandardItem *item);

--- a/src/Dialogs/MetaEditor.cpp
+++ b/src/Dialogs/MetaEditor.cpp
@@ -984,7 +984,7 @@ void MetaEditor::loadMetadataElements()
          tr("Custom Element") << "custom-element" << tr("An empty metadata element you can modify.")  << 
          tr("Meta Element (primary)") << "meta" << tr("An empty primary metadata element you can modify.");
     for (int i = 0; i < data.count(); i++) {
-        QString name = data.at(i++);
+        QString name = data.at(i++).trimmed();
         QString code = data.at(i++);
         QString description = data.at(i);
         DescriptiveInfo minfo;
@@ -1032,7 +1032,7 @@ void MetaEditor::loadMetadataProperties()
         tr("Custom Property") << "custom-property" << tr("An empty metadata property or attribute you can modify.");
 
     for (int i = 0; i < data.count(); i++) {
-        QString name = data.at(i++);
+        QString name = data.at(i++).trimmed();
         QString code = data.at(i++);
         QString description = data.at(i);
         DescriptiveInfo minfo;
@@ -1062,7 +1062,7 @@ void MetaEditor::loadMetadataXProperties()
         tr("Collection Type") << "collection-type" << tr("Property used with belongs-to-collection. Indicates the form or nature of a collection.") <<
         tr("Source of") << "source-of" << tr("Indicates a unique aspect of an adapted source resource that has been retained in the given Rendition of the EPUB Publication.");
     for (int i = 0; i < data.count(); i++) {
-        QString name = data.at(i++);
+        QString name = data.at(i++).trimmed();
         QString code = data.at(i++);
         QString description = data.at(i);
         DescriptiveInfo minfo;
@@ -1097,7 +1097,7 @@ void MetaEditor::loadE2MetadataXProperties()
         tr("Universally Unique Identifier") << "UUID"  << tr("Identifier Scheme: Universally Unique Identifier") <<
         tr("Amazon Unique Identifier") <<  "AMAZON" << tr("Identifier Scheme: Amazon Unique Identifier");
     for (int i = 0; i < data.count(); i++) {
-        QString name = data.at(i++);
+        QString name = data.at(i++).trimmed();
         QString code = data.at(i++);
         QString description = data.at(i);
         DescriptiveInfo minfo;
@@ -1153,7 +1153,7 @@ void MetaEditor::loadE2MetadataElements()
          tr("Custom Element") << "custom-element" << tr("An empty element for you to modify");
 
     for (int i = 0; i < data.count(); i++) {
-        QString name = data.at(i++);
+        QString name = data.at(i++).trimmed();
         QString code = data.at(i++);
         QString description = data.at(i);
         DescriptiveInfo meta;
@@ -1187,7 +1187,7 @@ void MetaEditor::loadE2MetadataProperties()
          tr("Custom Attribute") << "custom-property" << tr("An empty metadata attribute you can modify.");
 
     for (int i = 0; i < data.count(); i++) {
-        QString name = data.at(i++);
+        QString name = data.at(i++).trimmed();
         QString code = data.at(i++);
         QString description = data.at(i);
         DescriptiveInfo minfo;

--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -238,6 +238,11 @@ void AdjustImage::saveToReverseHistory(QImage imageToSave)
 
 void AdjustImage::resizeImage(int targetW, int targetH)
 {
+    // no size change so don't record a history step or rescale the image
+    if (targetW == m_image.width() && targetH == m_image.height()) {
+        return;
+    }
+
     saveToHistoryWithClear(m_image);
     QPixmap pixmap(m_imageLabel->pixmap());
     pixmap = pixmap.scaled(targetW, targetH, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -363,7 +368,8 @@ void AdjustImage::toggleFullscreen()
 
 void AdjustImage::doResizeImage()
 {
-    saveToHistoryWithClear(m_image);
+    // only record history once the resize is actually applied in resizeImage()
+    // so canceling the dialog leaves the undo/redo stacks untouched
     int width = m_image.width();
     int height = m_image.height();
     ImageResizeDialog dlg(width, height, this);


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes focused on enhancing the Table of Contents (TOC) editing experience, improving metadata handling, and refining image adjustment operations. The most significant changes include enabling multi-selection and bulk movement of TOC entries, trimming whitespace from metadata names, and optimizing image resizing behavior.

**TOC Editing Enhancements:**

* Added support for extended selection in the TOC editor, allowing users to select and move multiple TOC entries at once. The movement operations (`MoveLeft`, `MoveRight`, `MoveUp`, `MoveDown`) have been refactored to handle multiple selections and to properly reselect and expand moved items (`EditTOC.cpp`, `EditTOC.h`). [[1]](diffhunk://#diff-83a2cc7517492a5b18fe18afaf2ff7212adb12035fb66b376840bf610985569fR74) [[2]](diffhunk://#diff-83a2cc7517492a5b18fe18afaf2ff7212adb12035fb66b376840bf610985569fR164-R325) [[3]](diffhunk://#diff-b64ef36bac5eda3b88e4b750682dd7e89ffcbd91199b5e13dc6f36c1740ff6beR79) [[4]](diffhunk://#diff-b64ef36bac5eda3b88e4b750682dd7e89ffcbd91199b5e13dc6f36c1740ff6beR88)
* Introduced the `CheckSelections()` method to retrieve all selected TOC entries, supplementing the existing single-selection logic (`EditTOC.cpp`, `EditTOC.h`). [[1]](diffhunk://#diff-83a2cc7517492a5b18fe18afaf2ff7212adb12035fb66b376840bf610985569fR381-L360) [[2]](diffhunk://#diff-b64ef36bac5eda3b88e4b750682dd7e89ffcbd91199b5e13dc6f36c1740ff6beR79)

**Metadata Handling Improvements:**

* Ensured that metadata element and property names are trimmed of leading/trailing whitespace before use, preventing subtle bugs and inconsistencies in metadata management (`MetaEditor.cpp`). [[1]](diffhunk://#diff-e49cb48e3bf33703d21a99bed55c18c3ade56ad43487eec01b1c43ab660b061eL987-R987) [[2]](diffhunk://#diff-e49cb48e3bf33703d21a99bed55c18c3ade56ad43487eec01b1c43ab660b061eL1035-R1035) [[3]](diffhunk://#diff-e49cb48e3bf33703d21a99bed55c18c3ade56ad43487eec01b1c43ab660b061eL1065-R1065) [[4]](diffhunk://#diff-e49cb48e3bf33703d21a99bed55c18c3ade56ad43487eec01b1c43ab660b061eL1100-R1100) [[5]](diffhunk://#diff-e49cb48e3bf33703d21a99bed55c18c3ade56ad43487eec01b1c43ab660b061eL1156-R1156) [[6]](diffhunk://#diff-e49cb48e3bf33703d21a99bed55c18c3ade56ad43487eec01b1c43ab660b061eL1190-R1190)

**Image Adjustment Optimizations:**

* Prevented unnecessary history entries and image rescaling when the requested image size matches the current size, optimizing performance and undo/redo stack management (`AdjustImage.cpp`). [[1]](diffhunk://#diff-8cf528eaaf09b58afc817d6a0e89bda84ae9bc304ce7e4652df36d1f53bf12c0R241-R245) [[2]](diffhunk://#diff-8cf528eaaf09b58afc817d6a0e89bda84ae9bc304ce7e4652df36d1f53bf12c0L366-R372)

**Other:**

* Updated copyright years to 2026 in relevant files. [[1]](diffhunk://#diff-83a2cc7517492a5b18fe18afaf2ff7212adb12035fb66b376840bf610985569fL3-R3) [[2]](diffhunk://#diff-b64ef36bac5eda3b88e4b750682dd7e89ffcbd91199b5e13dc6f36c1740ff6beL3-R3)
* Modernized Qt header includes for consistency and potential build improvements (`EditTOC.cpp`).